### PR TITLE
feat: pin yaba Docker image version with Renovate auto-updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ name: Build and test
 on:
   push:
     branches: [ "main" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "main" ]
 
@@ -47,20 +48,30 @@ jobs:
   docker:
     runs-on: ubuntu-22.04
     steps:
+    - uses: actions/checkout@v4
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login to Docker Hub
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: wenbenz/yaba
+        tags: |
+          type=semver,pattern={{version}}
+          type=sha,format=long
+          type=raw,value=latest,enable={{is_default_branch}}
     - name: Build and push
       uses: docker/build-push-action@v6.7.0
       with:
         platforms: linux/amd64,linux/arm64
-        push: ${{ github.ref == 'refs/heads/main' }}
-        tags: wenbenz/yaba:latest , wenbenz/yaba:${{ github.sha }}
-        no-cache: ${{ github.ref == 'refs/heads/main' }}
+        push: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
+        tags: ${{ steps.meta.outputs.tags }}
+        no-cache: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Create a password file.
 echo "POSTGRES PASSWORD HERE" > db_password.txt
 ```
 
-Pull docker image.
+Pull docker image (replace `latest` with a specific [release tag](https://github.com/wenbenz/yaba/releases) for a pinned version).
 ```shell
-docker pull wenbenz/yaba
+docker pull wenbenz/yaba:latest
 ```
 
 Start containers.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -22,6 +22,17 @@ docker build --tag wenbenz/yaba --progress plain --no-cache .
 
 The `Dockerfile` configures the image to bind bind to port 9222.
 
+## Publishing a release
+
+To publish a versioned Docker image, create and push a git tag. The CI workflow will automatically build and push `wenbenz/yaba:<version>` to Docker Hub.
+
+```shell
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+[Renovate](https://docs.renovatebot.com/) is configured in `renovate.json` to detect new Docker image versions and open pull requests to update `manifests/yaba/values.yaml` automatically.
+
 # DB Migrations
 
 This project uses [go-migrate](https://github.com/golang-migrate/migrate) to manage migrations.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["manifests/yaba/values\\.yaml"],
+      "matchStrings": [
+        "image: docker\\.io/(?<depName>[^:]+):(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `tags: [ "v*" ]` trigger to the CI workflow so pushing a git tag like `v1.0.0` triggers a Docker build
- Uses `docker/metadata-action` to automatically generate semver Docker tags (e.g. `wenbenz/yaba:1.0.0`) from git tags
- Adds `renovate.json` with a custom regex manager to detect the image in `manifests/yaba/values.yaml` and open PRs automatically when new Docker versions are published on Docker Hub
- Updates `README.md` and `docs/DEVELOPMENT.md` with release process documentation

## How to release

```shell
git tag v1.0.0
git push origin v1.0.0
```

This triggers the CI to build and push `wenbenz/yaba:1.0.0` to Docker Hub. Renovate will then open a PR to update `manifests/yaba/values.yaml` automatically.

## Test plan

- [ ] Push a `v*` tag and verify the Docker job runs and publishes a semver-tagged image
- [ ] Confirm Renovate opens a PR to update `values.yaml` after the first release

🤖 Generated with [Claude Code](https://claude.com/claude-code)