### PR TITLE
feat: split yaba.image into repository/tag map for Renovate helmValues support

### DIFF
--- a/manifests/yaba/templates/deployment.yaml
+++ b/manifests/yaba/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app.kubernetes.io/name: yaba
     spec:
       containers:
-        - image: {{ .Values.yaba.image }}
+        - image: {{ .Values.yaba.image.repository }}:{{ .Values.yaba.image.tag }}
           imagePullPolicy: Always
           name: yaba
           ports:

--- a/manifests/yaba/values.yaml
+++ b/manifests/yaba/values.yaml
@@ -3,7 +3,9 @@ global:
 
 yaba:
   replicas: 1
-  image: docker.io/wenbenz/yaba:latest
+  image:
+    repository: docker.io/wenbenz/yaba
+    tag: "1.0.0"
   resources:
     requests:
       cpu: 100m

--- a/renovate.json
+++ b/renovate.json
@@ -2,15 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["manifests/yaba/values\\.yaml"],
-      "matchStrings": [
-        "image: docker\\.io/(?<depName>[^:]+):(?<currentValue>[^\\s]+)"
-      ],
-      "datasourceTemplate": "docker"
-    }
   ]
 }


### PR DESCRIPTION
## Summary

- **REQ-001** — `manifests/yaba/values.yaml`: replace the single-string `yaba.image: docker.io/wenbenz/yaba:latest` with a map containing `repository: docker.io/wenbenz/yaba` and `tag: "1.0.0"`.
- **REQ-002** — `manifests/yaba/templates/deployment.yaml`: update the container image reference from `{{ .Values.yaba.image }}` to `{{ .Values.yaba.image.repository }}:{{ .Values.yaba.image.tag }}`.
- **REQ-003** — `renovate.json`: remove the `customManagers` regex block. The built-in `helmValues` manager (included via `config:recommended`) automatically detects `repository`/`tag` sibling keys and will update the tag going forward — no custom regex needed.

## Why

Renovate's `helmValues` manager understands the `repository`/`tag` map pattern natively. Using a flat string required a fragile custom regex; splitting into the standard map lets Renovate track the Docker image tag without any extra configuration.

## Test plan

- [ ] `helm template manifests/yaba` renders a valid image string (`docker.io/wenbenz/yaba:1.0.0`)
- [ ] No other templates under `manifests/yaba/templates/` reference `.Values.yaba.image` as a scalar
- [ ] `renovate.json` is valid JSON and still extends `config:recommended`
- [ ] Renovate dry-run detects the `docker.io/wenbenz/yaba` image via the `helmValues` manager after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)