### PR TITLE
feat: SMTP email service

### DIFF
--- a/internal/email/mailer.go
+++ b/internal/email/mailer.go
@@ -1,0 +1,11 @@
+package email
+
+// Mailer sends transactional emails.
+type Mailer interface {
+	Send(to, subject, htmlBody string) error
+}
+
+// NoopMailer discards all mail silently. Used when SMTP is not configured.
+type NoopMailer struct{}
+
+func (NoopMailer) Send(_, _, _ string) error { return nil }

--- a/internal/email/smtp_mailer.go
+++ b/internal/email/smtp_mailer.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -45,7 +46,9 @@ func (m *SMTPMailer) Send(to, subject, htmlBody string) error {
 }
 
 func (m *SMTPMailer) sendImplicitTLS(addr, to string, msg []byte) error {
-	conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: m.cfg.Host})
+	dialer := &tls.Dialer{Config: &tls.Config{ServerName: m.cfg.Host}}
+
+	conn, err := dialer.DialContext(context.Background(), "tcp", addr)
 	if err != nil {
 		return fmt.Errorf("smtp tls dial: %w", err)
 	}
@@ -79,7 +82,11 @@ func (m *SMTPMailer) sendImplicitTLS(addr, to string, msg []byte) error {
 		return fmt.Errorf("smtp write body: %w", err)
 	}
 
-	return w.Close()
+	if err = w.Close(); err != nil {
+		return fmt.Errorf("smtp close data writer: %w", err)
+	}
+
+	return nil
 }
 
 func buildMIMEMessage(from, to, subject, htmlBody string) []byte {

--- a/internal/email/smtp_mailer.go
+++ b/internal/email/smtp_mailer.go
@@ -1,0 +1,95 @@
+package email
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+)
+
+// SMTPConfig holds connection details for an SMTP server.
+type SMTPConfig struct {
+	Host     string
+	Port     string
+	Username string
+	Password string
+	From     string
+}
+
+// SMTPMailer sends email via SMTP. Port 465 uses implicit TLS; all other ports
+// use STARTTLS via smtp.SendMail.
+type SMTPMailer struct {
+	cfg SMTPConfig
+}
+
+func NewSMTPMailer(cfg SMTPConfig) *SMTPMailer {
+	return &SMTPMailer{cfg: cfg}
+}
+
+func (m *SMTPMailer) Send(to, subject, htmlBody string) error {
+	addr := net.JoinHostPort(m.cfg.Host, m.cfg.Port)
+	msg := buildMIMEMessage(m.cfg.From, to, subject, htmlBody)
+
+	if m.cfg.Port == "465" {
+		return m.sendImplicitTLS(addr, to, msg)
+	}
+
+	auth := smtp.PlainAuth("", m.cfg.Username, m.cfg.Password, m.cfg.Host)
+
+	if err := smtp.SendMail(addr, auth, m.cfg.From, []string{to}, msg); err != nil {
+		return fmt.Errorf("smtp send: %w", err)
+	}
+
+	return nil
+}
+
+func (m *SMTPMailer) sendImplicitTLS(addr, to string, msg []byte) error {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{ServerName: m.cfg.Host})
+	if err != nil {
+		return fmt.Errorf("smtp tls dial: %w", err)
+	}
+
+	client, err := smtp.NewClient(conn, m.cfg.Host)
+	if err != nil {
+		return fmt.Errorf("smtp new client: %w", err)
+	}
+	defer client.Close()
+
+	auth := smtp.PlainAuth("", m.cfg.Username, m.cfg.Password, m.cfg.Host)
+
+	if err = client.Auth(auth); err != nil {
+		return fmt.Errorf("smtp auth: %w", err)
+	}
+
+	if err = client.Mail(m.cfg.From); err != nil {
+		return fmt.Errorf("smtp MAIL FROM: %w", err)
+	}
+
+	if err = client.Rcpt(to); err != nil {
+		return fmt.Errorf("smtp RCPT TO: %w", err)
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("smtp DATA: %w", err)
+	}
+
+	if _, err = w.Write(msg); err != nil {
+		return fmt.Errorf("smtp write body: %w", err)
+	}
+
+	return w.Close()
+}
+
+func buildMIMEMessage(from, to, subject, htmlBody string) []byte {
+	header := strings.Join([]string{
+		"MIME-Version: 1.0",
+		`Content-Type: text/html; charset="UTF-8"`,
+		"From: " + from,
+		"To: " + to,
+		"Subject: " + subject,
+	}, "\r\n")
+
+	return fmt.Appendf(nil, "%s\r\n\r\n%s", header, htmlBody)
+}

--- a/internal/email/smtp_mailer_test.go
+++ b/internal/email/smtp_mailer_test.go
@@ -13,6 +13,45 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// smtpLineResult is the action to take after processing one SMTP client line.
+type smtpLineResult int
+
+const (
+	smtpContinue  smtpLineResult = iota // keep reading
+	smtpDataReady                       // entering DATA mode
+	smtpBodyDone                        // DATA body complete — body is ready
+	smtpQuit                            // QUIT received — close connection
+)
+
+// handleSMTPLine processes one line from the SMTP client, writes the
+// appropriate response to conn, and returns the next action to take.
+func handleSMTPLine(conn net.Conn, body *strings.Builder, line string, inData bool) smtpLineResult {
+	switch {
+	case strings.HasPrefix(line, "EHLO"):
+		_, _ = fmt.Fprintln(conn, "250-test\r\n250 AUTH PLAIN LOGIN")
+	case strings.HasPrefix(line, "AUTH"):
+		_, _ = fmt.Fprintln(conn, "235 OK")
+	case strings.HasPrefix(line, "MAIL FROM"), strings.HasPrefix(line, "RCPT TO"):
+		_, _ = fmt.Fprintln(conn, "250 OK")
+	case line == "DATA":
+		_, _ = fmt.Fprintln(conn, "354 Start input")
+
+		return smtpDataReady
+	case inData && line == ".":
+		_, _ = fmt.Fprintln(conn, "250 OK")
+
+		return smtpBodyDone
+	case inData:
+		body.WriteString(line + "\n")
+	case strings.HasPrefix(line, "QUIT"):
+		_, _ = fmt.Fprintln(conn, "221 Bye")
+
+		return smtpQuit
+	}
+
+	return smtpContinue
+}
+
 // runFakeSMTPServer starts a minimal fake SMTP server on ln and returns a
 // channel that receives the DATA body once a complete message is accepted.
 func runFakeSMTPServer(t *testing.T, ln net.Listener) <-chan string {
@@ -38,27 +77,14 @@ func runFakeSMTPServer(t *testing.T, ln net.Listener) <-chan string {
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			switch {
-			case strings.HasPrefix(line, "EHLO"):
-				_, _ = fmt.Fprintln(conn, "250-test\r\n250 AUTH PLAIN LOGIN")
-			case strings.HasPrefix(line, "AUTH"):
-				_, _ = fmt.Fprintln(conn, "235 OK")
-			case strings.HasPrefix(line, "MAIL FROM"):
-				_, _ = fmt.Fprintln(conn, "250 OK")
-			case strings.HasPrefix(line, "RCPT TO"):
-				_, _ = fmt.Fprintln(conn, "250 OK")
-			case line == "DATA":
+			switch handleSMTPLine(conn, &body, line, inData) {
+			case smtpDataReady:
 				inData = true
-				_, _ = fmt.Fprintln(conn, "354 Start input")
-			case inData && line == ".":
-				inData = false
+			case smtpBodyDone:
 				captured <- body.String()
-				_, _ = fmt.Fprintln(conn, "250 OK")
-			case inData:
-				body.WriteString(line + "\n")
-			case strings.HasPrefix(line, "QUIT"):
-				_, _ = fmt.Fprintln(conn, "221 Bye")
 
+				inData = false
+			case smtpQuit:
 				return
 			}
 		}

--- a/internal/email/smtp_mailer_test.go
+++ b/internal/email/smtp_mailer_test.go
@@ -2,6 +2,7 @@ package email_test
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -12,12 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSMTPMailerSend(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer ln.Close()
-
-	_, port, _ := net.SplitHostPort(ln.Addr().String())
+// runFakeSMTPServer starts a minimal fake SMTP server on ln and returns a
+// channel that receives the DATA body once a complete message is accepted.
+func runFakeSMTPServer(t *testing.T, ln net.Listener) <-chan string {
+	t.Helper()
 
 	captured := make(chan string, 1)
 
@@ -26,9 +25,11 @@ func TestSMTPMailerSend(t *testing.T) {
 		if err != nil {
 			return
 		}
+
 		defer conn.Close()
 
 		var body strings.Builder
+
 		scanner := bufio.NewScanner(conn)
 		inData := false
 
@@ -36,6 +37,7 @@ func TestSMTPMailerSend(t *testing.T) {
 
 		for scanner.Scan() {
 			line := scanner.Text()
+
 			switch {
 			case strings.HasPrefix(line, "EHLO"):
 				_, _ = fmt.Fprintln(conn, "250-test\r\n250 AUTH PLAIN LOGIN")
@@ -56,10 +58,28 @@ func TestSMTPMailerSend(t *testing.T) {
 				body.WriteString(line + "\n")
 			case strings.HasPrefix(line, "QUIT"):
 				_, _ = fmt.Fprintln(conn, "221 Bye")
+
 				return
 			}
 		}
 	}()
+
+	return captured
+}
+
+func TestSMTPMailerSend(t *testing.T) {
+	t.Parallel()
+
+	lc := &net.ListenConfig{}
+
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	defer ln.Close()
+
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	captured := runFakeSMTPServer(t, ln)
 
 	m := email.NewSMTPMailer(email.SMTPConfig{
 		Host:     "127.0.0.1",
@@ -80,6 +100,9 @@ func TestSMTPMailerSend(t *testing.T) {
 }
 
 func TestNoopMailer(t *testing.T) {
+	t.Parallel()
+
 	var m email.Mailer = email.NoopMailer{}
+
 	assert.NoError(t, m.Send("to@example.com", "subject", "<p>body</p>"))
 }

--- a/internal/email/smtp_mailer_test.go
+++ b/internal/email/smtp_mailer_test.go
@@ -86,6 +86,7 @@ func runFakeSMTPServer(t *testing.T, ln net.Listener) <-chan string {
 				inData = false
 			case smtpQuit:
 				return
+			case smtpContinue:
 			}
 		}
 	}()

--- a/internal/email/smtp_mailer_test.go
+++ b/internal/email/smtp_mailer_test.go
@@ -1,0 +1,85 @@
+package email_test
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"yaba/internal/email"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSMTPMailerSend(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	_, port, _ := net.SplitHostPort(ln.Addr().String())
+
+	captured := make(chan string, 1)
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		var body strings.Builder
+		scanner := bufio.NewScanner(conn)
+		inData := false
+
+		_, _ = fmt.Fprintln(conn, "220 test ready")
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "EHLO"):
+				_, _ = fmt.Fprintln(conn, "250-test\r\n250 AUTH PLAIN LOGIN")
+			case strings.HasPrefix(line, "AUTH"):
+				_, _ = fmt.Fprintln(conn, "235 OK")
+			case strings.HasPrefix(line, "MAIL FROM"):
+				_, _ = fmt.Fprintln(conn, "250 OK")
+			case strings.HasPrefix(line, "RCPT TO"):
+				_, _ = fmt.Fprintln(conn, "250 OK")
+			case line == "DATA":
+				inData = true
+				_, _ = fmt.Fprintln(conn, "354 Start input")
+			case inData && line == ".":
+				inData = false
+				captured <- body.String()
+				_, _ = fmt.Fprintln(conn, "250 OK")
+			case inData:
+				body.WriteString(line + "\n")
+			case strings.HasPrefix(line, "QUIT"):
+				_, _ = fmt.Fprintln(conn, "221 Bye")
+				return
+			}
+		}
+	}()
+
+	m := email.NewSMTPMailer(email.SMTPConfig{
+		Host:     "127.0.0.1",
+		Port:     port,
+		Username: "user",
+		Password: "pass",
+		From:     "from@example.com",
+	})
+
+	err = m.Send("to@example.com", "Test Subject", "<p>Hello world</p>")
+	require.NoError(t, err)
+
+	body := <-captured
+	assert.Contains(t, body, "Subject: Test Subject")
+	assert.Contains(t, body, "From: from@example.com")
+	assert.Contains(t, body, "To: to@example.com")
+	assert.Contains(t, body, "<p>Hello world</p>")
+}
+
+func TestNoopMailer(t *testing.T) {
+	var m email.Mailer = email.NoopMailer{}
+	assert.NoError(t, m.Send("to@example.com", "subject", "<p>body</p>"))
+}

--- a/internal/handlers/resolver.go
+++ b/internal/handlers/resolver.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"github.com/jackc/pgx/v5/pgxpool"
+	"yaba/internal/email"
 )
 
 // This file will not be regenerated automatically.
@@ -9,5 +10,6 @@ import (
 // It serves as dependency injection for your app, add any dependencies you require here.
 
 type Resolver struct {
-	Pool *pgxpool.Pool
+	Pool   *pgxpool.Pool
+	Mailer email.Mailer
 }

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -66,6 +66,6 @@ func routeReactPages(mux *http.ServeMux) {
 
 func routeReactPage(mux *http.ServeMux, path string) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, os.Getenv("UI_ROOT_DIR")+"/index.html") //nolint:gosec // path is from trusted env var, not user input
+		http.ServeFile(w, r, os.Getenv("UI_ROOT_DIR")+"/index.html") //nolint:gosec // env var, not user input
 	})
 }

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -9,13 +9,15 @@ import (
 	"os"
 	"yaba/graph/server"
 	"yaba/internal/auth"
+	"yaba/internal/email"
 )
 
-func BuildServerHandler(pool *pgxpool.Pool) (http.Handler, error) {
+func BuildServerHandler(pool *pgxpool.Pool, mailer email.Mailer) (http.Handler, error) {
 	mux := http.NewServeMux()
 
 	gqlHandler := handler.New(server.NewExecutableSchema(server.Config{Resolvers: &Resolver{
-		Pool: pool,
+		Pool:   pool,
+		Mailer: mailer,
 	}}))
 	gqlHandler.AddTransport(transport.GET{})
 	gqlHandler.AddTransport(transport.POST{})

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -66,6 +66,6 @@ func routeReactPages(mux *http.ServeMux) {
 
 func routeReactPage(mux *http.ServeMux, path string) {
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, os.Getenv("UI_ROOT_DIR")+"/index.html")
+		http.ServeFile(w, r, os.Getenv("UI_ROOT_DIR")+"/index.html") //nolint:gosec // path is from trusted env var, not user input
 	})
 }

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func buildMailer() email.Mailer {
 	var password string
 
 	if passwordFile != "" {
-		raw, err := os.ReadFile(passwordFile)
+		raw, err := os.ReadFile(passwordFile) //nolint:gosec // path comes from trusted env var, not user input
 		if err != nil {
 			log.Fatalln("could not read SMTP_PASSWORD_FILE:", err)
 		}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 	"yaba/internal/database"
 	"yaba/internal/email"
@@ -93,12 +94,17 @@ func buildMailer() email.Mailer {
 			log.Fatalln("could not read SMTP_PASSWORD_FILE:", err)
 		}
 
-		password = string(raw)
+		password = strings.TrimSpace(string(raw))
+	}
+
+	port := os.Getenv("SMTP_PORT")
+	if port == "" {
+		port = "587"
 	}
 
 	return email.NewSMTPMailer(email.SMTPConfig{
 		Host:     host,
-		Port:     os.Getenv("SMTP_PORT"),
+		Port:     port,
 		Username: os.Getenv("SMTP_USERNAME"),
 		Password: password,
 		From:     os.Getenv("SMTP_FROM"),

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"time"
 	"yaba/internal/database"
+	"yaba/internal/email"
 	"yaba/internal/handlers"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -43,7 +44,9 @@ func main() {
 
 	log.Println("Migrations applied successfully!")
 
-	rootHandler, err := handlers.BuildServerHandler(pool)
+	mailer := buildMailer()
+
+	rootHandler, err := handlers.BuildServerHandler(pool, mailer)
 	if err != nil {
 		log.Fatalln("could not build root handler:", err)
 	}
@@ -68,6 +71,38 @@ func main() {
 
 	err = yabaServer.ListenAndServe()
 	log.Fatalln("Failed to start server", err)
+}
+
+// buildMailer constructs an SMTPMailer from environment variables, or returns a
+// NoopMailer when SMTP_HOST is not set (development / no-email mode).
+func buildMailer() email.Mailer {
+	host := os.Getenv("SMTP_HOST")
+	if host == "" {
+		log.Println("SMTP_HOST not set — email sending disabled")
+
+		return email.NoopMailer{}
+	}
+
+	passwordFile := os.Getenv("SMTP_PASSWORD_FILE")
+
+	var password string
+
+	if passwordFile != "" {
+		raw, err := os.ReadFile(passwordFile)
+		if err != nil {
+			log.Fatalln("could not read SMTP_PASSWORD_FILE:", err)
+		}
+
+		password = string(raw)
+	}
+
+	return email.NewSMTPMailer(email.SMTPConfig{
+		Host:     host,
+		Port:     os.Getenv("SMTP_PORT"),
+		Username: os.Getenv("SMTP_USERNAME"),
+		Password: password,
+		From:     os.Getenv("SMTP_FROM"),
+	})
 }
 
 func waitForConnection(pool *pgxpool.Pool) error {


### PR DESCRIPTION
## Summary

- Adds `internal/email` package with a `Mailer` interface and `SMTPMailer` implementation
- `SMTPMailer` supports both STARTTLS (port 587) and implicit TLS (port 465)
- `NoopMailer` fallback used when `SMTP_HOST` env var is not set (email silently disabled)
- Password read from `SMTP_PASSWORD_FILE` (consistent with `POSTGRES_PASSWORD_FILE` pattern)
- Wired into `BuildServerHandler` and `Resolver` as a dependency

**Env vars:**
| Var | Required | Purpose |
|-----|----------|---------|
| `SMTP_HOST` | No (disables email if absent) | SMTP server hostname |
| `SMTP_PORT` | Yes (if host set) | e.g. `587` or `465` |
| `SMTP_USERNAME` | Yes (if host set) | Auth username |
| `SMTP_PASSWORD_FILE` | Yes (if host set) | Path to file containing password |
| `SMTP_FROM` | Yes (if host set) | Sender address |

## Test plan

- [x] `go test ./internal/email/...` — fake SMTP server test verifies correct MIME headers and body
- [x] `go build ./...` — compiles cleanly
- [ ] Manual: set SMTP env vars pointing to a test SMTP relay and observe a sent email

🤖 Generated with [Claude Code](https://claude.com/claude-code)